### PR TITLE
Do not crash on force unwrap when - for some reason (simulator) no ca…

### DIFF
--- a/ALCameraViewController/Views/CameraView.swift
+++ b/ALCameraViewController/Views/CameraView.swift
@@ -32,6 +32,9 @@ public class CameraView: UIView {
                 device.flashMode = .auto
                 device.unlockForConfiguration()
             } catch _ {}
+        } else {
+            print("Error: No Camera device found")
+            return
         }
 
         let outputSettings = [AVVideoCodecKey: AVVideoCodecJPEG]


### PR DESCRIPTION
…mera device is found.

Instead, print the error and return early. Allowing to at least use the image picker.